### PR TITLE
[FIX] stock: put stored related field product_code in compute_sudo

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -320,9 +320,9 @@ class InventoryLine(models.Model):
         'product.product', 'Product',
         index=True, required=True)
     product_name = fields.Char(
-        'Product Name', related='product_id.name', store=True, readonly=True)
+        'Product Name', related='product_id.name', store=True, readonly=True, compute_sudo=True)
     product_code = fields.Char(
-        'Product Code', related='product_id.default_code', store=True)
+        'Product Code', related='product_id.default_code', store=True, readonly=True, compute_sudo=True)
     product_uom_id = fields.Many2one(
         'product.uom', 'Product Unit of Measure',
         required=True,


### PR DESCRIPTION
Have a multi-company setup, with shared products.
Write the default code of a product; an access error is raised on inventory.line

On inventory.line, the field product_code is defined as related to 'product_id.default_code', and stored.
So when writing on the default_code of a product, we get the inventory lines of other companies. For obvious reasons their access is protected by the record rule "Inventory Line multi-company", therefore the access error is raised.

To avoid that situation stored related fields should be in compute_sudo.

Note that similarly this is necessary for product_name. There is one more subtlety: directly writing on the product.product does trigger the access error, but writing it on the product.template does not.

backport of 11.0 #34019
opw-2007167
opw-2074842
closes #37889

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
